### PR TITLE
Fix VS2019 support by removing unneeded legacy dependency.

### DIFF
--- a/ConvertProjectToCore3/source.extension.vsixmanifest
+++ b/ConvertProjectToCore3/source.extension.vsixmanifest
@@ -14,7 +14,6 @@
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,17.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Fix issues #2 

According to this blog post by Mads Kristensen: [How to upgrade extensions to support Visual Studio 2019](https://blogs.msdn.microsoft.com/visualstudio/2018/09/26/how-to-upgrade-extensions-to-support-visual-studio-2019/)

**Microsoft.VisualStudio.MPF.15.0** is a legacy dependency, should be removed to support VS2019.